### PR TITLE
use colon vs equals for consistency in config files

### DIFF
--- a/Orbiter O2 Toolboard/Klipper Config/OrbitoolO2.cfg
+++ b/Orbiter O2 Toolboard/Klipper Config/OrbitoolO2.cfg
@@ -10,7 +10,7 @@ restart_method: command
 ###########################################################################################
 
 [output_pin O2run_led]
-pin = orbitoolO2:PB8
+pin: orbitoolO2:PB8
 value: 1
 shutdown_value: 0
 
@@ -21,43 +21,43 @@ shutdown_value: 0
 # you may need to change some setting based on the hotend type you have
 
 [extruder]
-step_pin = orbitoolO2:PB7
-#dir_pin = !orbitoolO2:PB6 #orbiter quatro
-dir_pin = orbitoolO2:PB6 #orbiter 2
-enable_pin = !orbitoolO2:PB4
-microsteps = 32
-rotation_distance = 4.69 # Orbiter v2
-full_steps_per_rotation = 200
-nozzle_diameter = 0.400
-filament_diameter = 1.750
-heater_pin = orbitoolO2:PA0
-sensor_pin = orbitoolO2:PA3
-pullup_resistor = 2200
-sensor_type = ATC Semitec 104GT-2 # hotend speciffic
-min_temp = 0
-max_temp = 300 # hotend speciffic
-pressure_advance = 0.02
-pressure_advance_smooth_time = 0.03
-max_extrude_only_distance = 500.0
-max_extrude_cross_section = 20
-min_extrude_temp = 180
-#min_extrude_temp = 30
-smooth_time = 0.5
+step_pin: orbitoolO2:PB7
+#dir_pin: !orbitoolO2:PB6 #orbiter quatro
+dir_pin: orbitoolO2:PB6 #orbiter 2
+enable_pin: !orbitoolO2:PB4
+microsteps: 32
+rotation_distance: 4.69 # Orbiter v2
+full_steps_per_rotation: 200
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: orbitoolO2:PA0
+sensor_pin: orbitoolO2:PA3
+pullup_resistor: 2200
+sensor_type: ATC Semitec 104GT-2 # hotend speciffic
+min_temp: 0
+max_temp: 300 # hotend speciffic
+pressure_advance: 0.02
+pressure_advance_smooth_time: 0.03
+max_extrude_only_distance: 500.0
+max_extrude_cross_section: 20
+min_extrude_temp: 180
+#min_extrude_temp: 30
+smooth_time: 0.5
 max_power: 0.995 # limit heater power to 99.5% to enable autorecovery from short detection
 pwm_cycle_time: 0.00500
-control = pid # hotend speciffic
-pid_Kp=23.145 
-pid_Ki=1.513 
-pid_Kd=88.532
+control: pid # hotend speciffic
+pid_Kp: 23.145 
+pid_Ki: 1.513 
+pid_Kd: 88.532
 
 [tmc2209 extruder]
 uart_pin: orbitoolO2:PB5
-interpolate = False
-run_current = 0.8 # Orbiter 2
-#run_current = 0.6 # Orbiter quatro
-#hold_current = 0.100
-sense_resistor = 0.11
-stealthchop_threshold = 0
+interpolate: False
+run_current: 0.8 # Orbiter 2
+#run_current: 0.6 # Orbiter quatro
+#hold_current: 0.100
+sense_resistor: 0.11
+stealthchop_threshold: 0
 
 [firmware_retraction]
 retract_length: 1.2

--- a/Orbiter O2S Toolboard/Kipper Config/Orbitool_O2S.cfg
+++ b/Orbiter O2S Toolboard/Kipper Config/Orbitool_O2S.cfg
@@ -19,32 +19,32 @@ serial:/dev/serial/by-id/usb-Klipper_stm32f072xb_Orbitool_O2S-if00
 restart_method: command
 
 [extruder]
-step_pin = orbitoolO2S:PB3
-dir_pin = !orbitoolO2S:PB4
-enable_pin = !orbitoolO2S:PC14
-microsteps = 32
-rotation_distance = 4.69 # Orbiter v2.5
-full_steps_per_rotation = 200
-nozzle_diameter = 0.400
-filament_diameter = 1.750
-heater_pin = orbitoolO2S:PB9
-sensor_pin = orbitoolO2S:PA1
-pullup_resistor = 2200
-sensor_type = ATC Semitec 104GT-2 # update with correct sensor type PT1000 sensor are also suported
+step_pin: orbitoolO2S:PB3
+dir_pin: !orbitoolO2S:PB4
+enable_pin: !orbitoolO2S:PC14
+microsteps: 32
+rotation_distance: 4.69 # Orbiter v2.5
+full_steps_per_rotation: 200
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: orbitoolO2S:PB9
+sensor_pin: orbitoolO2S:PA1
+pullup_resistor: 2200
+sensor_type: ATC Semitec 104GT-2 # update with correct sensor type PT1000 sensor are also suported
 #sensor_type: PT1000
-min_temp = 0
-max_temp = 300 # increase in case your hottend suports higher operating temperature
-pressure_advance = 0.015  # user calibration needed
-pressure_advance_smooth_time = 0.03 # user calibration needed
-max_extrude_only_distance = 500.0
-max_extrude_cross_section = 20
-min_extrude_temp = 20
-smooth_time = 0.5
+min_temp: 0
+max_temp: 300 # increase in case your hottend suports higher operating temperature
+pressure_advance: 0.015  # user calibration needed
+pressure_advance_smooth_time: 0.03 # user calibration needed
+max_extrude_only_distance: 500.0
+max_extrude_cross_section: 20
+min_extrude_temp: 20
+smooth_time: 0.5
 max_power: 0.995 # limit heater power to 99.5% to enable autorecovery from short detection
-control = pid   # user calibration needed
-pid_Kp=25.566 
-pid_Ki=1.794 
-pid_Kd=91.080
+control: pid   # user calibration needed
+pid_Kp: 25.566 
+pid_Ki: 1.794 
+pid_Kd: 91.080
 
 
 [tmc2240 extruder] 

--- a/Orbiter SO3 Toolboard/Klipper Config/SO3.cfg
+++ b/Orbiter SO3 Toolboard/Klipper Config/SO3.cfg
@@ -92,7 +92,7 @@ dir_pin: SO3:PB6
 enable_pin: !SO3:PB4
 microsteps: 32
 full_steps_per_rotation: 200
-#rotation_distance = <full_steps_per_rotation> * <microsteps> / <steps_per_mm>
+#rotation_distance: <full_steps_per_rotation> * <microsteps> / <steps_per_mm>
 rotation_distance: 4.69
 nozzle_diameter: 0.400
 filament_diameter: 1.750
@@ -114,10 +114,10 @@ smooth_time: 0.5
 max_extrude_cross_section:10
 max_power: 0.995
 pwm_cycle_time: 0.01
-control = pid
-pid_Kp=24.859 
-pid_Ki=2.072 
-pid_Kd=74.578
+control: pid
+pid_Kp: 24.859 
+pid_Ki: 2.072 
+pid_Kd: 74.578
 
 [tmc2209 extruder] 
 uart_pin: SO3:PB5


### PR DESCRIPTION
The example configs have a mixture of `=` and `:` for the field/value separator.  While both work, the`field: value` format seems more prevalent, and is the preferred syntax by the Klipper team per item 7.d here: https://www.klipper3d.org/Example_Configs.html.  I mostly noticed because the `field = value` format seems to trip up the mainsail config editor's syntax highlighting.

Thanks for the great printer parts!